### PR TITLE
fix: implement `isReducible` and apply to `MTEXT` to properly concat group code 3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/parser/entities/mtext/parser.ts
+++ b/src/parser/entities/mtext/parser.ts
@@ -137,15 +137,20 @@ export const MTextEntityParserSnippets: DXFParserSnippet[] = [
     {
         code: 3,
         name: 'text',
-        parser(curr, scanner, entity) {
-            // Code 1에다 추가로 더 달아야 함
-            return (entity.text ?? '') + curr.value;
+        parser(curr, _, entity) {
+            entity._code3text = (entity._code3text ?? '') + curr.value;
+            return entity._code3text + (entity._code1text ?? '');
         },
+        isMultiple: true,
+        isReducible: true,
     },
     {
         code: 1,
         name: 'text',
-        parser: Identity,
+        parser(curr, _, entity) {
+            entity._code1text = curr.value;
+            return (entity._code3text ?? '') + entity._code1text;
+        },
     },
     {
         code: 72,

--- a/src/parser/shared/parserGenerator.test.ts
+++ b/src/parser/shared/parserGenerator.test.ts
@@ -123,6 +123,61 @@ describe('createParser', () => {
         expect(curr.code).toBe(2);
     });
 
+    describe('isReducible', () => {
+        it('should return multiple values as array when isReducible is false', () => {
+            const parse = createParser([
+                {
+                    code: 1,
+                    name: 'a',
+                    isMultiple: true,
+                    parser: Identity,
+                },
+            ]);
+
+            const scanner = new DxfArrayScanner([
+                '1',
+                'x',
+                '1',
+                'x',
+                'EOF',
+            ]);
+
+            const obj = {} as any;
+            let curr = scanner.next();
+            parse(curr, scanner, obj);
+
+            expect(obj.a instanceof Array).toBeTruthy();
+        })
+
+        it('should return reduced single value when isReducible is true', () => {
+            const parse = createParser([
+                {
+                    code: 10,
+                    name: 'a',
+                    isMultiple: true,
+                    isReducible: true,
+                    // replace as sum with its previous value
+                    parser: (curr, _, obj) => (obj.a ?? 0) + curr.value,
+                },
+            ]);
+
+            const scanner = new DxfArrayScanner([
+                '10',
+                '1',
+                '10',
+                '2',
+                'EOF',
+            ]);
+
+            const obj = {} as any;
+            let curr = scanner.next();
+            parse(curr, scanner, obj);
+
+            expect(obj.a instanceof Array).toBeFalsy();
+            expect(obj.a).toBe(3)
+        })
+    })
+
     it('pushContext가 걸린 경우, 새로 생긴 맥락부터 뒤져본다.', () => {
         const parse = createParser([
             {

--- a/src/parser/shared/parserGenerator.ts
+++ b/src/parser/shared/parserGenerator.ts
@@ -19,7 +19,10 @@ export interface DXFParserSnippet {
     // 만약 Abort 심볼이 반환될 경우 값에 대입하지 않고 읽은 것을 한 칸 되돌리고
     // 종료함
     parser?(curr: ScannerGroup, scanner: DxfArrayScanner, entity: any): any;
-    isMultiple?: boolean; // code가 여러 번 들어올 수 있는 경우, true로 표기
+    /** When specific group code can be read multiple times, set this `true` */
+    isMultiple?: boolean;
+    /** When isMultiple is `true`, save array when `false`, replace as is when `true` */
+    isReducible?: boolean; 
 
     // https://github.com/connect-for-you/cadview-front/issues/41
     // 이 스니펫을 기점으로 맥락을 바꿈
@@ -61,7 +64,7 @@ export function createParser(
                 snippetMap[curr.code].pop();
             }
 
-            const { name, parser, isMultiple } = snippet;
+            const { name, parser, isMultiple, isReducible } = snippet;
             const parsedValue = parser?.(curr, scanner, target);
 
             if (parsedValue === Abort) {
@@ -72,7 +75,7 @@ export function createParser(
             if (name) {
                 const [leaf, fieldName] = getObjectByPath(target, name);
 
-                if (isMultiple) {
+                if (isMultiple && !isReducible) {
                     // default value is injected via prototype, therefore have to check their own properties
                     if (!Object.prototype.hasOwnProperty.call(leaf, fieldName)) {
                         leaf[fieldName] = [];

--- a/src/parser/shared/parserGenerator.ts
+++ b/src/parser/shared/parserGenerator.ts
@@ -73,9 +73,8 @@ export function createParser(
                 const [leaf, fieldName] = getObjectByPath(target, name);
 
                 if (isMultiple) {
-                    // prototype으로 디폴트값 넣어준 경우 nullish coalescing으로 해결 안됨 
-                    // @ts-ignore
-                    if (!Object.hasOwn(leaf, fieldName)) {
+                    // default value is injected via prototype, therefore have to check their own properties
+                    if (!Object.prototype.hasOwnProperty.call(leaf, fieldName)) {
                         leaf[fieldName] = [];
                     }
                     leaf[fieldName].push(parsedValue);
@@ -158,8 +157,7 @@ function getObjectByPath(target: any, path: string) {
     let currentTarget = target;
     for (let depth = 0; depth < fragments.length - 1; ++depth) {
         const currentName = fragments[depth];
-        // @ts-ignore
-        if (!Object.hasOwn(currentTarget, currentName)) {
+        if (!Object.prototype.hasOwnProperty.call(currentTarget, currentName)) {
             currentTarget[currentName] = {};
         }
         currentTarget = currentTarget[currentName];


### PR DESCRIPTION
## Overview
<!---- Please briefly describe the changes and related issues. Please explain what and why you modified it rather than how. -->
- Force to use workspace typescript version for vscode
- Use `Object.prototype.hasOwnProperty` instead of ES2022 `Object.hasOwn` since the target of this project is `ES2020`
- Implement `isReducible` and its test case
- Apply to `MTEXT` ot properly concatenate group code 3

<!---- Resolves: #(Isuue Number) -->
#11 

## PR category
What changes?

- [x] Add new features
- [x] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [x] Add and edit comments
- [ ] Edit document
- [x] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
