### PR TITLE
feat: support `IMAGE` entity

### DIFF
--- a/src/parser/entities/image/consts.ts
+++ b/src/parser/entities/image/consts.ts
@@ -1,0 +1,16 @@
+export enum ImageFlags {
+  ShowImage = 1,
+  ShowImageWhenNotAlignedWithScreen = 2,
+  UseClippingBoundary = 4,
+  TransparencyIsOn = 8,
+}
+
+export enum ImageClippingBoundaryType {
+  Rectangular = 1,
+  Polygonal = 2,
+}
+
+export enum ImageClipMode {
+  Outside = 0,
+  Inside = 1,
+}

--- a/src/parser/entities/image/index.ts
+++ b/src/parser/entities/image/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './consts'
+export * from './parser'

--- a/src/parser/entities/image/parser.ts
+++ b/src/parser/entities/image/parser.ts
@@ -1,0 +1,122 @@
+import type DxfArrayScanner from '../../DxfArrayScanner';
+import type { ScannerGroup } from '../../DxfArrayScanner';
+import { CommonEntitySnippets } from '../shared';
+import {
+    createParser,
+    DXFParserSnippet,
+    Identity,
+    PointParser,
+    ToBoolean,
+} from '../../shared/parserGenerator';
+import type { ImageEntity } from './types'
+
+const DefaultImageEntity = {
+    brightness: 50,
+    contrast: 50,
+    fade: 0,
+    clippingBoundaryPath: []
+};
+
+const ImageEntityParserSnippets: DXFParserSnippet[] = [
+    {
+        code: 290,
+        name: 'clipMode',
+        parser: Identity,
+    },
+    {
+        code: 14,
+        name: 'clippingBoundaryPath',
+        isMultiple: true,
+        parser: PointParser,
+    },
+    {
+        code: 91,
+        name: 'countBoundaryPoints',
+        parser: Identity,
+    },
+    {
+        code: 71,
+        name: 'clippingBoundaryType',
+        parser: Identity,
+    },
+    {
+        code: 360,
+        name: 'imageDefReactorHandle',
+        parser: Identity,
+    },
+    {
+        code: 283,
+        name: 'fade',
+        parser: Identity,
+    },
+    {
+        code: 282,
+        name: 'contrast',
+        parser: Identity,
+    },
+    {
+        code: 281,
+        name: 'brightness',
+        parser: Identity,
+    },
+    {
+        code: 280,
+        name: 'isClipped',
+        parser: ToBoolean,
+    },
+    {
+        code: 70,
+        name: 'flags',
+        parser: Identity,
+    },
+    {
+        code: 340,
+        name: 'imageDefHandle',
+        parser: Identity,
+    },
+    {
+        code: 13,
+        name: 'imageSize',
+        parser: PointParser,
+    },
+    {
+        code: 12,
+        name: 'vPixel',
+        parser: PointParser,
+    },
+    {
+        code: 11,
+        name: 'uPixel',
+        parser: PointParser,
+    },
+    {
+        code: 10,
+        name: 'position',
+        parser: PointParser,
+    },
+    {
+        code: 90,
+        name: 'version',
+        parser: Identity,
+    },
+    {
+        code: 100,
+        name: 'subclassMarker',
+        parser: Identity,
+    },
+    ...CommonEntitySnippets,
+];
+
+export class ImageEntityParser {
+    static ForEntityName = 'IMAGE';
+    private parser = createParser(
+        ImageEntityParserSnippets,
+        DefaultImageEntity,
+    );
+
+    parseEntity(scanner: DxfArrayScanner, curr: ScannerGroup) {
+        const entity = {} as any;
+        this.parser(curr, scanner, entity);
+        return entity as ImageEntity;
+    }
+}

--- a/src/parser/entities/image/types.ts
+++ b/src/parser/entities/image/types.ts
@@ -1,0 +1,55 @@
+import type { Point2D, Point3D } from '../../../types';
+import type { CommonDxfEntity } from '../shared';
+import type { ImageClipMode, ImageClippingBoundaryType } from './consts';
+
+export interface ImageEntity extends CommonDxfEntity {
+    type: 'IMAGE';
+    subclassMarker: 'AcDbRasterImage';
+    /** Class version */
+    version: number;
+    /** Insertion point (in WCS) */
+    position: Point3D;
+    /** 
+     * U-vector of a single pixel (points along the visual bottom of the image, 
+     * starting at the insertion point) (in WCS) 
+     * */
+    uPixel: Point3D;
+    /** 
+     * V-vector of a single pixel (points along the visual left side of the image, 
+     * starting at the insertion point) (in WCS) 
+     * */
+    vPixel: Point3D;
+    /** Image size in pixels */
+    imageSize: Point2D;
+    /** Hard reference to imagedef object */
+    imageDefHandle: string;
+    /** 
+     * Image display properties
+     * @see {import("./consts").ImageFlags}
+     * */
+    flags: number;
+    /** Clipping state. `true` if it's clipping state is ON, `false` when OFF */
+    isClipped: boolean;
+    /** Brightness value (0-100; default = 50) */
+    brightness: number;
+    /** Contrast value (0-100; default = 50) */
+    contrast: number;
+    /** Fade value (0-100; default = 0) */
+    fade: number;
+    /** Hard reference to imagedef_reactor object */
+    imageDefReactorHandle: string;
+    /** Clipping boundary type */
+    clippingBoundaryType: ImageClippingBoundaryType;
+    /** Number of clip boundary vertices that follow */
+    countBoundaryPoints: number;
+    /** 
+     * Clip boundary vertex (in OCS) 
+     * @note 
+     * 1. For rectangular clip boundary type, two opposite corners must be specified. 
+     *    Default is (-0.5,-0.5), (size.x-0.5, size.y-0.5). 
+     * 2. For polygonal clip boundary type, three or more vertices must be specified. 
+     *    Polygonal vertices must be listed sequentially
+     * */
+    clippingBoundaryPath: Point2D[];
+    clipMode: ImageClipMode;
+}

--- a/src/parser/entities/index.ts
+++ b/src/parser/entities/index.ts
@@ -11,6 +11,7 @@ import { AttributeEntityParser } from "./attribute";
 import { CircleEntityParser } from "./circle";
 import Dimension from "./dimension";
 import { EllipseEntityParser } from "./ellipse";
+import { ImageEntityParser } from "./image";
 import { InsertEntityParser } from "./insert";
 import { LeaderEntityParser } from "./leader";
 import { LineEntityParser } from "./line/parser";
@@ -34,6 +35,7 @@ const Parsers = Object.fromEntries(
     CircleEntityParser,
     Dimension,
     EllipseEntityParser,
+    ImageEntityParser,
     InsertEntityParser,
     LeaderEntityParser,
     LineEntityParser,

--- a/src/parser/entities/types.ts
+++ b/src/parser/entities/types.ts
@@ -4,6 +4,8 @@ export * from "./circle";
 export * from "./dimension";
 export * from "./ellipse";
 export * from "./hatch";
+export * from './image/types'
+export type * from './image/consts'
 export * from "./insert";
 export * from "./leader";
 export * from "./line";

--- a/src/parser/entities/types.ts
+++ b/src/parser/entities/types.ts
@@ -4,8 +4,7 @@ export * from "./circle";
 export * from "./dimension";
 export * from "./ellipse";
 export * from "./hatch";
-export * from './image/types'
-export type * from './image/consts'
+export type * from './image'
 export * from "./insert";
 export * from "./leader";
 export * from "./line";


### PR DESCRIPTION
## Overview
<!---- Please briefly describe the changes and related issues. Please explain what and why you modified it rather than how. -->
- Implement IMAGE ENTITY parser
  - Add proper constants
  - Add types with JSDoc comment copied from [#official-doc](https://help.autodesk.com/view/OARX/2024/ENU/?guid=GUID-3A2FF847-BE14-4AC5-9BD4-BD3DCAEF2281)
  - Split `consts` from `types`
  - Relay export for external access
- Mostly taken from the implementation of @AquafinaSun (thank you!), but several enhancements were applied
  - `imageSize` should be `Point2D`, not `Point3D`
  - Default value of `brightness`, `contrast`, `fade` were set
  - Since the parser uses stack internally, schema should be defined reversely to the order of the official document. Yeah, shamefuly, this is not described properly in the repository. I'll add them soon.
  - Change `clipping` to `isClipped` with `boolean` type for convenience

<!---- Resolves: #(Isuue Number) -->
#25

## PR category
What changes?

- [x] Add new features
- [ ] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [x] Add and edit comments
- [ ] Edit document
- [ ] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [ ] Tested the changes (bug fixes/tested features).

cc @dotoritos-kim 

I couldn't find ANY SINGLE DXF sample file that having natural `IMAGE` ENTITY inside.
There is a [#python sample script](https://ezdxf.readthedocs.io/en/stable/tutorials/image.html) in ezdxf which generates DXF having `IMAGE`.
But I don't think it's appropriate to use it as it's not generated from production app like AutoCAD or any third party program.