### PR TITLE
feat: parse application specific extensions

### DIFF
--- a/src/parser/ParseHelpers.ts
+++ b/src/parser/ParseHelpers.ts
@@ -1,6 +1,7 @@
+import { parseExtensions } from '@src/parser/shared/extensions/parser';
 import type DxfArrayScanner from './DxfArrayScanner';
 import type { ScannerGroup } from './DxfArrayScanner';
-import { skipApplicationGroups, type CommonDxfEntity } from './entities/shared';
+import type { CommonDxfEntity } from './entities/shared';
 import { isMatched } from './shared/isMatched';
 import { parseXData } from './shared/xdata';
 import { getAcadColor } from './getAcadColor';
@@ -31,7 +32,7 @@ export function skipEmbeddedObject(scanner: DxfArrayScanner) {
  */
 export function checkCommonEntityProperties(entity: CommonDxfEntity, curr: ScannerGroup, scanner: DxfArrayScanner) {
     if (isMatched(curr, 102)) {
-        skipApplicationGroups(curr, scanner);
+        parseExtensions(curr, scanner, entity);
         return true;
     }
 
@@ -43,14 +44,7 @@ export function checkCommonEntityProperties(entity: CommonDxfEntity, curr: Scann
             entity.handle = curr.value as string;
             break;
         case 330:
-            if (!entity.ownerDictionarySoftId) {
-                entity.ownerDictionarySoftId = curr.value;
-            } else {
-                entity.ownerBlockRecordSoftId = curr.value;
-            }
-            break;
-        case 360:
-            entity.ownerdictionaryHardId = curr.value;
+            entity.ownerBlockRecordSoftId = curr.value;
             break;
         case 67:
             entity.isInPaperSpace = !!curr.value;

--- a/src/parser/entities/entities.test.ts
+++ b/src/parser/entities/entities.test.ts
@@ -82,5 +82,57 @@ EOF
             expect(entities[0].handle).toBe('entity-0');
             expect(entities[1].handle).toBe('entity-1');
         });
+
+        it('should parse app extension properly', () => {
+            const content = ` 0
+LINE
+ 5
+entity-0
+102
+{ACAD_REACTORS
+330
+soft-id
+102
+}
+102
+{ACAD_XDICTIONARY
+360
+hard-id
+102
+}
+102
+{FOO
+2
+bar
+102
+}
+330
+D9B071D01A0ACD38
+  100
+AcDbLine
+  100
+AcDbEntity
+  0
+ENDSEC
+  0
+EOF`.split('\n')
+            const scanner = new DxfArrayScanner(content)
+            let curr = scanner.next()
+
+            const entities = parseEntities(curr, scanner)
+            
+            expect(entities.length).toBe(1)
+            expect(entities[0].extensions).toMatchObject({
+                'ACAD_REACTORS': [
+                    { code: 330, value: 'soft-id' },
+                ],
+                'ACAD_XDICTIONARY': [
+                    { code: 360, value: 'hard-id' },
+                ],
+                'FOO': [
+                    { code: 2, value: 'bar' },
+                ]
+            })
+        })
     });
 });

--- a/src/parser/entities/shared.ts
+++ b/src/parser/entities/shared.ts
@@ -1,7 +1,7 @@
-import type { ColorIndex, ColorInstance } from '../../types';
-import DxfArrayScanner, { ScannerGroup } from '../DxfArrayScanner';
+import type { ScannerGroup } from '@src/parser/DxfArrayScanner';
+import { parseExtensions } from '@src/parser/shared/extensions/parser';
+import type { ColorIndex, ColorInstance } from '@src/types';
 import { getAcadColor } from '../getAcadColor';
-import { isMatched } from '../shared';
 import {
     DXFParserSnippet,
     Identity,
@@ -29,8 +29,12 @@ export interface CommonDxfEntity {
     plotStyleHardId?: string;
     shadowMode?: ShadowMode;
     xdata?: XData;
-    ownerdictionaryHardId?: string | number | boolean;
-    ownerDictionarySoftId?: string | number | boolean;
+    /** 
+     * Application specific extension by their application-name. 
+     * As it differs by application, you have to parse by your own.
+     * Note that group codes 102 for brackets are not included in the array.
+     * */
+    extensions?: Record<string, ScannerGroup[]>
 }
 
 export enum ShadowMode {
@@ -137,15 +141,15 @@ export const CommonEntitySnippets: DXFParserSnippet[] = [
     },
     {
         code: 102, // {ACAD_XDICTIONARY
-        parser: skipApplicationGroups,
+        parser: parseExtensions,
     },
     {
         code: 102, // {ACAD_REACTORS
-        parser: skipApplicationGroups,
+        parser: parseExtensions,
     },
     {
         code: 102, // {application_name
-        parser: skipApplicationGroups,
+        parser: parseExtensions,
     },
     {
         code: 5,
@@ -153,14 +157,3 @@ export const CommonEntitySnippets: DXFParserSnippet[] = [
         parser: Identity,
     },
 ];
-
-export function skipApplicationGroups(
-    curr: ScannerGroup,
-    scanner: DxfArrayScanner,
-) {
-    curr = scanner.next();
-    while (!isMatched(curr, 102) && !isMatched(curr, 0, 'EOF')) {
-        curr = scanner.next();
-    }
-    // } 까지 소비
-}

--- a/src/parser/shared/extensions/parser.ts
+++ b/src/parser/shared/extensions/parser.ts
@@ -1,0 +1,40 @@
+import DxfArrayScanner, { ScannerGroup } from "@src/parser/DxfArrayScanner";
+import { isMatched } from "../isMatched";
+
+/** @internal */
+export function parseExtensions(curr: ScannerGroup, scanner: DxfArrayScanner, entity: any) {
+    while (isMatched(curr, 102)) {
+        const rawValue = curr.value as string
+        curr = scanner.next();
+
+        if (!rawValue.startsWith('{')) {
+            console.warn(`Invalid application group, expected to start with "{" but received: ${rawValue}`);
+            
+            skipInvalidExtension(curr, scanner) // after this, scanner points at the next group of 102 }
+            curr = scanner.next() 
+            continue;
+        }
+    
+        // application-name is form of {appName
+        const appName = rawValue.slice(1).trim()
+
+        entity.extensions ??= {}
+        entity.extensions[appName] ??= []
+        
+        parseApplicationGroup(curr, scanner, entity.extensions[appName])
+        curr = scanner.next()
+    }
+}
+
+function skipInvalidExtension(curr: ScannerGroup, scanner: DxfArrayScanner) {
+    while (!isMatched(curr, 102) && !isMatched(curr, 0, 'EOF')) {
+        curr = scanner.next();
+    }
+}
+
+function parseApplicationGroup(curr: ScannerGroup, scanner: DxfArrayScanner, groupCodes: any) {
+    while (!isMatched(curr, 102, '}') && !isMatched(curr, 0, 'EOF')) {
+        groupCodes.push(curr);
+        curr = scanner.next();
+    }
+}


### PR DESCRIPTION
## Overview

- Implement application specific extensions parsing
  - Previousely, they were skipped
  - Add types, tests

Every group codes in application block will be stored directly with parsed type.
See this example.

```
// Raw Data
102
{FOO
2
a
70
3.141592
102
}
102
{BAR
330
ABCDEF
102
}

// Parsed Data
{
  extensions: {
    FOO: [{ code: 2, value: 'a' }, { code: 70, value: 3.141592 }],
    BAR: [{ fcode: 330, value: 'ABCDEF' }],
  }
}
```

Note that this extension parser will be used for other sections like OBJECT.

### BREAKING CHANGES

- Remove `ownerDictionarySoftId` and `ownerDictionaryHardId` from `ENTITY`
  - Since they are in **inside of the extension block**, they should go in to inner scope.

I think most user don't use such advanced fields, but if you experience your app breaking, I'm really sorry for that. 
As we're not in 1.0, more general structure without exception should be taken for stable version.

## PR category
What changes?

- [x] Add new features
- [ ] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [ ] Add and edit comments
- [ ] Edit document
- [x] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
