### PR TITLE
fix: add missing exports for xdata and extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc && rollup --config",
     "test": "jest --silent=false",
-    "analyze": "depcruise src --include-only \".*(types|index|consts).ts\" --output-type dot | dot -Gsplines=ortho -T svg > dependency-graph.svg"
+    "analyze": "depcruise src --include-only \".*(types|index|consts).ts\" -T dot | dot -Grankdir=TD -Gsplines=ortho -T svg > dependency-graph.svg"
   },
   "repository": {
     "type": "git",

--- a/src/parser/shared/index.ts
+++ b/src/parser/shared/index.ts
@@ -1,4 +1,6 @@
 export * from './isMatched'
+export * from './xdata'
+export * from './extensions/parser'
 
 let lastHandle = 0;
 

--- a/src/parser/tables/index.ts
+++ b/src/parser/tables/index.ts
@@ -1,2 +1,11 @@
+export type * from './blockRecord'
+export type * from './dimStyle'
+export type * from './layer'
+export type * from './ltype'
+export type * from './style'
+export type * from './vport'
 export type * from './types';
+
+export * from './dimStyle/consts'
+export * from './ltype/consts'
 export * from './parser';

--- a/src/parser/tables/types.ts
+++ b/src/parser/tables/types.ts
@@ -1,10 +1,3 @@
-export type * from './blockRecord'
-export type * from './dimStyle'
-export type * from './layer'
-export type * from './ltype'
-export type * from './style'
-export type * from './vport'
-
 export interface DxfTable<T extends CommonDxfTableEntry> {
     subclassMarker: 'AcDbSymbolTable';
     name: string;


### PR DESCRIPTION
## Overview

- fix: resolve redundant circular dependency of TABLE related types
  - This is not a critical issue but prevent bothersome build issues
- fix: add missing exports for `xdata` and `extensions`
- improve: visualization of graph
  - change `rankdir` into `TD` so that entire orientation be landscape
  - FYI checkout the [graphviz dot docs](https://graphviz.org/doc/info/command.html)

<img width="4473" height="784" alt="image" src="https://github.com/user-attachments/assets/b06d6c00-2f07-442b-b604-d3e0c5a35735" />

## PR category
What changes?

- [ ] Add new features
- [x] Bug fix
- [x] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [ ] Add and edit comments
- [ ] Edit document
- [ ] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [ ] Tested the changes (bug fixes/tested features).
