### PR TITLE
fix: replace `at` to access by index to match es2020

### DIFF
--- a/src/parser/shared/parserGenerator.ts
+++ b/src/parser/shared/parserGenerator.ts
@@ -56,7 +56,8 @@ export function createParser(
                 curr.code,
                 contextIndex,
             );
-            const snippet = snippetMap?.[curr.code].at(-1);
+            const snippetsForCode = snippetMap?.[curr.code]
+            const snippet = snippetsForCode?.[snippetsForCode.length - 1]
 
             if (!snippetMap || !snippet) {
                 scanner.rewind();
@@ -125,7 +126,7 @@ function createSnippetMaps(snippets: DXFParserSnippet[], debug?: boolean) {
 					if (debug)
 						console.warn(
 							`Snippet ${
-								bin.at(-1)!.name
+								bin[bin.length - 1].name
 							} for code(${code}) is shadowed by ${snippet.name}`
 						);
 				}
@@ -181,7 +182,7 @@ export function getObjectByPath(target: any, path: string): [any, string | numbe
         }
         parent = parent[currentName];
     }
-    return [parent, refineName(fragments.at(-1)!)];
+    return [parent, refineName(fragments[fragments.length - 1])];
 }
 
 function refineName(name: string): string | number {

--- a/src/parser/shared/xdata/parser.ts
+++ b/src/parser/shared/xdata/parser.ts
@@ -28,7 +28,7 @@ export function parseXData(curr: ScannerGroup, scanner: DxfArrayScanner) {
     const stack = [xdata.value] as any[][];
 
     while (!isMatched(curr, 0, 'EOF') && curr.code >= 1000) {
-        const top = stack.at(-1)!;
+        const top = stack[stack.length - 1];
 
         switch (curr.code) {
             case 1002:
@@ -36,7 +36,7 @@ export function parseXData(curr: ScannerGroup, scanner: DxfArrayScanner) {
                     stack.push([]);
                 } else {
                     stack.pop();
-                    stack.at(-1)?.push(top);
+                    stack[stack.length - 1]?.push(top);
                 }
                 break;
             case 1000: // string


### PR DESCRIPTION
## Overview

- `Array.prototype.at` is [es2022 specification](https://caniuse.com/?search=es2022) 
- currently we support es2020
- I'm not sure why build error was not thrown before #60

## PR category
What changes?

- [ ] Add new features
- [x] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [ ] Add and edit comments
- [ ] Edit document
- [ ] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
