### PR TITLE
fix: remove `dist` directory when build

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "print": "vite-node src/script/print.ts"
   },
-  "devDependencies": {
+  "dependencies": {
     "dxf-json": "file:.."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "dxf-json",
       "version": "1.0.0",
-      "dev": true,
       "license": "GPL-3.0",
       "workspaces": [
         "integration-test"
@@ -31,7 +30,7 @@
       }
     },
     "integration-test": {
-      "devDependencies": {
+      "dependencies": {
         "dxf-json": "file:.."
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc && rollup --config",
-    "test": "jest --silent=false",
+    "build": "rm -r dist && tsc && rollup --config",
+    "test": "jest --silent=false && npm run build && npm run typetest",
     "analyze": "depcruise src --include-only \".*(types|index|consts).ts\" -T dot | dot -Grankdir=TD -Gsplines=ortho -T svg > dependency-graph.svg",
     "new": "vite-node scripts/create-snippet.ts",
     "typetest": "npm --workspace=integration-test run build"


### PR DESCRIPTION
## Overview

Since `tsc` caching is inconsistent, safely remove `dist` directory for each `build` command.
Even I fixed the type issue, I found `dist` always has outdated result. This affects integration type test.

Now we can say we're more robust to changes, thanks to the heavy test setting.

## PR category
What changes?

- [ ] Add new features
- [x] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [ ] Add and edit comments
- [ ] Edit document
- [ ] Add tests, refactor tests
- [x] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
