### PR TITLE
fix: inconsitent name of dimension horizontal align enum

### DIFF
--- a/src/consts/dimension.ts
+++ b/src/consts/dimension.ts
@@ -54,11 +54,26 @@ export enum DimensionZeroSuppressionAngular {
     LeadingAndTrailing = 3,
 }
 
+/**
+ * Justify horizontal alignment of dimension text 
+ */
 export enum DimensionTextHorizontal {
     Center = 0,
-    Left = 1,
-    Right = 2,
+    /** Above dimension line and next to first extension line */
+    First = 1,
+    /** Above dimension line and next to second extension line */
+    Second = 2,
+    /** 
+     * Above and center-justified to first extension line
+     * 
+     * In linear dimension, typically it's rotated in 90 degrees to extension line.
+     */
     OverFirst = 3,
+    /** 
+     * Above and center-justified to second extension line
+     * 
+     * In linear dimension, typically it's rotated in 90 degrees to extension line.
+     */
     OverSecond = 4,
 }
 


### PR DESCRIPTION
## Overview

- #90

## PR category

- Change `DimensionTextHorizontal.Left` to `DimensionTextHorizontal.First`
- Change `DimensionTextHorizontal.Right` to `DimensionTextHorizontal.Second`
- Former name was too confusing to user, as it's not guaranteed to ordered
- From v1.0 there will be no breaking change as possible

---

- [ ] Add new features
- [ ] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [x] Code refactoring
- [ ] Add and edit comments
- [ ] Edit document
- [ ] Add tests, refactor tests
- [ ] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
