### PR TITLE
fix: type resolution in `package.json`, missing `DIMSTYLE` variables and exports

### DIFF
--- a/integration-test/tsconfig.json
+++ b/integration-test/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "skipLibCheck": true,
     "noUnusedLocals": false,

--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "module": "./dist/bundle.mjs",
   "types": "./dist/types/index.d.ts",
   "exports": {
-    "import": "./dist/bundle.mjs",
-    "require": "./dist/bundle.cjs"
+    "import": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/bundle.mjs"
+    },
+    "require": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/bundle.cjs"
+    }
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc --project tsconfig.build.json && rollup --config",

--- a/src/parser/entities/index.ts
+++ b/src/parser/entities/index.ts
@@ -14,7 +14,9 @@ export * from "./leader";
 export * from "./line";
 export * from "./lwpolyline";
 export * from './mesh'
+export * from './mline'
 export * from "./mtext";
+export * from "./multileader";
 export * from "./point";
 export * from "./polyline";
 export * from "./ray";
@@ -51,6 +53,7 @@ import { LWPolylineParser } from "./lwpolyline";
 import { MeshEntityParser } from "./mesh";
 import { MLineEntityParser } from "./mline";
 import { MTextEntityParser } from "./mtext";
+import { MultiLeaderEntityParser } from "./multileader";
 import { PointEntityParser } from "./point";
 import { PolylineParser } from "./polyline";
 import { RayParser } from "./ray";
@@ -67,8 +70,6 @@ import { ViewportParser } from "./viewport";
 import { WipeoutEntityParser } from "./wipeout";
 import { XLineEntityParser } from "./xline";
 import { CommonDxfEntity } from "./shared";
-
-import { MultiLeaderEntityParser } from "./multileader";
 
 const Parsers = Object.fromEntries(
 	[

--- a/src/parser/objects/index.ts
+++ b/src/parser/objects/index.ts
@@ -4,6 +4,7 @@ export * from './dictionary'
 export * from './layout'
 export * from './plotSettings'
 export * from './spatial_filter'
+export * from './xrecord'
 
 import type { DxfArrayScanner, ScannerGroup } from '../DxfArrayScanner';
 import { createParser, DXFParserSnippet } from '../shared/parserGenerator';

--- a/src/parser/tables/dimStyle/consts.ts
+++ b/src/parser/tables/dimStyle/consts.ts
@@ -308,6 +308,18 @@ export const DimStyleVariablesSchema = [
         code: 276,
         defaultValue: 0,
     },
+    // Sets the total length of the extension lines starting from the dimension line toward the dimension origin.
+    {
+        name: 'DIMFXL',
+        code: 49,
+        defaultValue: 1,
+    },
+    // Controls whether extension lines are set to a fixed length.
+    {
+        name: 'DIMFXLON',
+        code: 290,
+        defaultValue: 0,
+    },
     // Specifies units for all nonangular dimensions
     {
         name: 'DIMLUNIT',
@@ -411,6 +423,18 @@ export const DimStyleVariablesSchema = [
     {
         name: 'DIMBLK2',
         code: 344,
+    },
+    // Sets the linetype of the first extension line.
+    {
+        name: 'DIMLTEX1',
+        code: 346,
+        defaultValue: '',
+    },
+    // Sets the linetype of the second extension line.
+    {
+        name: 'DIMLTEX2',
+        code: 347,
+        defaultValue: '',
     },
     // Lineweight value for dimension lines
     {

--- a/src/parser/tables/dimStyle/types.ts
+++ b/src/parser/tables/dimStyle/types.ts
@@ -6,7 +6,12 @@ import type {
 } from '../../../consts';
 import type { CommonDxfTableEntry } from '../types';
 
-// https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-F2FAD36F-0CE3-4943-9DAD-A9BCD2AE81DA
+/**
+ * Union of all possible dimension style variable names.
+ * 
+ * @see DimStyleVariables
+ * @see https://help.autodesk.com/view/OARX/2025/ENU/?guid=GUID-F2FAD36F-0CE3-4943-9DAD-A9BCD2AE81DA
+ */
 export type DimStyleVariable =
     | 'DIMPOST'
     | 'DIMAPOST'
@@ -27,6 +32,8 @@ export type DimStyleVariable =
     | 'DIMTSZ'
     | 'DIMALTF'
     | 'DIMLFAC'
+    | 'DIMLTEX1'
+    | 'DIMLTEX2'
     | 'DIMTVP'
     | 'DIMTFAC'
     | 'DIMGAP'
@@ -57,6 +64,8 @@ export type DimStyleVariable =
     | 'DIMALTTD'
     | 'DIMAUNIT'
     | 'DIMFRAC'
+    | 'DIMFXL'
+    | 'DIMFXLON'
     | 'DIMLUNIT'
     | 'DIMDSEP'
     | 'DIMTMOVE'
@@ -85,6 +94,11 @@ export interface DimStyleVariableSchema {
     defaultValueImperial?: string | number;
 }
 
+/**
+ * Key-value pairs of dimension style variables. Useful when combined with `DimStyleVariable`.
+ * 
+ * @see DimStyleVariable
+ */
 export type DimStyleVariables = {
     DIMPOST?: string;
     DIMAPOST?: string;
@@ -105,6 +119,18 @@ export type DimStyleVariables = {
     DIMTSZ: number;
     DIMALTF: number;
     DIMLFAC: number;
+    /** 
+     * Sets the linetype of the first extension line. The value is `BYLAYER`, `BYBLOCK`, or the name of a linetype.
+     * 
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-535BAECA-312A-4841-A064-4FDB3469AAD0
+     */
+    DIMLTEX1: string;
+    /**
+     * Sets the linetype of the second extension line. The value is `BYLAYER`, `BYBLOCK`, or the name of a linetype.
+     * 
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-E2101E66-6741-40BF-B62D-E8201F51BA7F
+     */
+    DIMLTEX2: string;
     DIMTVP: number;
     DIMTFAC: number;
     DIMGAP: number;
@@ -135,6 +161,20 @@ export type DimStyleVariables = {
     DIMALTTD: number;
     DIMAUNIT: number;
     DIMFRAC: number;
+    /**
+     * Sets the total length of the extension lines starting from the dimension line toward the dimension origin.
+     * 
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-CC0F54D4-688B-4A14-9926-9840BCB30FCA
+     */
+    DIMFXL: number;
+    /**
+     * Controls whether extension lines are set to a fixed length.
+     * 
+     * When DIMFXLON is on (`1`), extension lines are set to the length specified by `DIMFXL`.
+     * 
+     * @see https://help.autodesk.com/view/ACD/2025/ENU/?guid=GUID-D0E2EA4A-4CA2-4286-9439-55A19726C166
+     */
+    DIMFXLON: 0 | 1;
     DIMLUNIT: number;
     DIMDSEP: string;
     DIMTMOVE: number;


### PR DESCRIPTION
## Overview

- #93
- #109 
- [fix: add types field to each exports entries in package.json](https://github.com/dotoritos-kim/dxf-json/commit/379bd3e811685eec5352025f8b29db7c93496167)
- [fix: add DIMFXL, DIMFXLON, DIMLTEX1, DIMLTEX2](https://github.com/dotoritos-kim/dxf-json/commit/ee65a24a1aeb80adf12f116baa757cf6f7c342a4)
- [fix: broken type test](https://github.com/dotoritos-kim/dxf-json/commit/888ea1893cc5c51479cf324d756a9d049e20fd90)
- [fix: add missing exports for MLINE, MLEADER and XRECORD](https://github.com/dotoritos-kim/dxf-json/commit/006f248dd6a254893abd863d6778dc03c0de2cad)

## PR category

What changes?

- [ ] Add new features
- [x] Bug fix
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names)
- [ ] Code refactoring
- [x] Add and edit comments
- [ ] Edit document
- [x] Add tests, refactor tests
- [x] Edit the build part or package manager
- [ ] Edit file or folder name
- [ ] Delete file or folder

## PR Checklist
Make sure your PR meets the following requirements:

- [x] Tested the changes (bug fixes/tested features).
