### PR TITLE
fix: header inconsistencies by normalizing header key names

### DIFF
--- a/src/parser/header/index.ts
+++ b/src/parser/header/index.ts
@@ -1,29 +1,46 @@
-import type { DxfArrayScanner, ScannerGroup } from '../DxfArrayScanner';
-import { parsePoint } from '../shared/parsePoint';
-import { isMatched } from '../shared';
+import type { DxfArrayScanner, ScannerGroup } from "../DxfArrayScanner";
+import { parsePoint } from "../shared/parsePoint";
+import { isMatched } from "../shared";
 
 // scanner 위치는 읽히기 전이어야 함
 export function parseHeader(curr: ScannerGroup, scanner: DxfArrayScanner) {
-    // interesting variables:
-    //  $ACADVER, $VIEWDIR, $VIEWSIZE, $VIEWCTR, $TDCREATE, $TDUPDATE
-    // http://www.autodesk.com/techpubs/autocad/acadr14/dxf/header_section_al_u05_c.htm
-    // Also see VPORT table entries
-    let currVarName = null;
-    const header: any = {};
+	// interesting variables:
+	//  $ACADVER, $VIEWDIR, $VIEWSIZE, $VIEWCTR, $TDCREATE, $TDUPDATE
+	// http://www.autodesk.com/techpubs/autocad/acadr14/dxf/header_section_al_u05_c.htm
+	// Also see VPORT table entries
+	let currVarName: string | null = null;
+	const header: any = {};
 
-    while (!isMatched(curr, 0, 'EOF')) {
-        if (isMatched(curr, 0, 'ENDSEC')) {
-            break;
-        }
+	const setHeaderValue = (name: string | null, value: any) => {
+		if (!name) return;
+		// 원본 그대로 보존
+		header[name] = value;
 
-        if (curr.code === 9) {
-            currVarName = curr.value;
-        } else if (curr.code === 10) {
-            header[currVarName] = parsePoint(scanner);
-        } else {
-            header[currVarName] = curr.value;
-        }
-        curr = scanner.next();
-    }
-    return header;
+		// 선행 $ 전부 제거 및 대문자 정규화
+		const canonical = name.replace(/^\$+/, "");
+		if (canonical) {
+			header[canonical] = value; // 무달러
+			header[`$${canonical}`] = value; // 싱글달러
+
+			const upper = canonical.toUpperCase();
+			header[upper] = value; // 무달러+대문자
+			header[`$${upper}`] = value; // 싱글달러+대문자
+		}
+	};
+
+	while (!isMatched(curr, 0, "EOF")) {
+		if (isMatched(curr, 0, "ENDSEC")) {
+			break;
+		}
+
+		if (curr.code === 9) {
+			currVarName = curr.value;
+		} else if (curr.code === 10) {
+			setHeaderValue(currVarName, parsePoint(scanner));
+		} else {
+			setHeaderValue(currVarName, curr.value);
+		}
+		curr = scanner.next();
+	}
+	return header;
 }

--- a/src/parser/header/index.ts
+++ b/src/parser/header/index.ts
@@ -13,19 +13,10 @@ export function parseHeader(curr: ScannerGroup, scanner: DxfArrayScanner) {
 
 	const setHeaderValue = (name: string | null, value: any) => {
 		if (!name) return;
-		// Preserve original key
-		header[name] = value;
-
-		// Strip leading '$' and add normalized uppercase variants
-		const canonical = name.replace(/^\$+/, "");
-		if (canonical) {
-			header[canonical] = value; // no-dollar
-			header[`$${canonical}`] = value; // single-dollar
-
-			const upper = canonical.toUpperCase();
-			header[upper] = value; // no-dollar + uppercase
-			header[`$${upper}`] = value; // single-dollar + uppercase
-		}
+		// Store only canonical header key: "$" + uppercase(name without leading '$')
+		const canonical = name.replace(/^\$+/, "").toUpperCase();
+		if (!canonical) return;
+		header[`$${canonical}`] = value;
 	};
 
 	while (!isMatched(curr, 0, "EOF")) {

--- a/src/parser/header/index.ts
+++ b/src/parser/header/index.ts
@@ -2,7 +2,7 @@ import type { DxfArrayScanner, ScannerGroup } from "../DxfArrayScanner";
 import { parsePoint } from "../shared/parsePoint";
 import { isMatched } from "../shared";
 
-// scanner 위치는 읽히기 전이어야 함
+// Scanner must be positioned before reading
 export function parseHeader(curr: ScannerGroup, scanner: DxfArrayScanner) {
 	// interesting variables:
 	//  $ACADVER, $VIEWDIR, $VIEWSIZE, $VIEWCTR, $TDCREATE, $TDUPDATE
@@ -13,18 +13,18 @@ export function parseHeader(curr: ScannerGroup, scanner: DxfArrayScanner) {
 
 	const setHeaderValue = (name: string | null, value: any) => {
 		if (!name) return;
-		// 원본 그대로 보존
+		// Preserve original key
 		header[name] = value;
 
-		// 선행 $ 전부 제거 및 대문자 정규화
+		// Strip leading '$' and add normalized uppercase variants
 		const canonical = name.replace(/^\$+/, "");
 		if (canonical) {
-			header[canonical] = value; // 무달러
-			header[`$${canonical}`] = value; // 싱글달러
+			header[canonical] = value; // no-dollar
+			header[`$${canonical}`] = value; // single-dollar
 
 			const upper = canonical.toUpperCase();
-			header[upper] = value; // 무달러+대문자
-			header[`$${upper}`] = value; // 싱글달러+대문자
+			header[upper] = value; // no-dollar + uppercase
+			header[`$${upper}`] = value; // single-dollar + uppercase
 		}
 	};
 

--- a/src/stream-parser/DxfStreamParser.ts
+++ b/src/stream-parser/DxfStreamParser.ts
@@ -135,17 +135,17 @@ export class DxfStreamParser extends EventTarget {
 						} else {
 							if (this._currVarName) {
 								const name = this._currVarName;
-								// 원본 보존
+								// Preserve original key
 								this.dxf.header[name] = headerValue;
-								// 정규화된 키들 동시 저장
+								// Store normalized key variants together
 								const canonical = name.replace(/^\$+/, "");
 								if (canonical) {
 									const upper = canonical.toUpperCase();
-									this.dxf.header[canonical] = headerValue; // 무달러
+									this.dxf.header[canonical] = headerValue; // no-dollar
 									this.dxf.header[`$${canonical}`] =
-										headerValue; // 싱글달러
-									this.dxf.header[upper] = headerValue; // 무달러+대문자
-									this.dxf.header[`$${upper}`] = headerValue; // 싱글달러+대문자
+										headerValue; // single-dollar
+									this.dxf.header[upper] = headerValue; // no-dollar + uppercase
+									this.dxf.header[`$${upper}`] = headerValue; // single-dollar + uppercase
 								}
 							}
 						}

--- a/src/stream-parser/DxfStreamParser.ts
+++ b/src/stream-parser/DxfStreamParser.ts
@@ -135,17 +135,13 @@ export class DxfStreamParser extends EventTarget {
 						} else {
 							if (this._currVarName) {
 								const name = this._currVarName;
-								// Preserve original key
-								this.dxf.header[name] = headerValue;
-								// Store normalized key variants together
-								const canonical = name.replace(/^\$+/, "");
+								// Store only canonical header key: "$" + uppercase(name without leading '$')
+								const canonical = name
+									.replace(/^\$+/, "")
+									.toUpperCase();
 								if (canonical) {
-									const upper = canonical.toUpperCase();
-									this.dxf.header[canonical] = headerValue; // no-dollar
 									this.dxf.header[`$${canonical}`] =
-										headerValue; // single-dollar
-									this.dxf.header[upper] = headerValue; // no-dollar + uppercase
-									this.dxf.header[`$${upper}`] = headerValue; // single-dollar + uppercase
+										headerValue;
 								}
 							}
 						}

--- a/src/stream-parser/DxfStreamParser.ts
+++ b/src/stream-parser/DxfStreamParser.ts
@@ -1,230 +1,250 @@
-import {
-  parseGroupValue,
-  type ScannerGroup,
-} from "../parser/DxfArrayScanner";
+import { parseGroupValue, type ScannerGroup } from "../parser/DxfArrayScanner";
 import { isMatched } from "../parser/shared";
 import type { ParsedDxf } from "../parser/types";
 import { parsePoint } from "./streamShared/parseData";
 
 type ErrorOptions =
-  | {
-      cause: Error;
-    }
-  | undefined;
+	| {
+			cause: Error;
+	  }
+	| undefined;
 
 /** Options for {@link DxfStreamParser} construction. */
 export class DxfStreamParserOptions {
-  /** Encoding label.
-   * See https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
-   */
-  encoding: string = "utf-8";
-  /** Throw `TypeError` when encountering invalid encoded data when true. When false, the decoder
-   * will substitute malformed data with a replacement character.
-   */
-  encodingFailureFatal: boolean = false;
+	/** Encoding label.
+	 * See https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
+	 */
+	encoding: string = "utf-8";
+	/** Throw `TypeError` when encountering invalid encoded data when true. When false, the decoder
+	 * will substitute malformed data with a replacement character.
+	 */
+	encodingFailureFatal: boolean = false;
 }
 
 export class DxfParsingError extends Error {
-  readonly line: number;
+	readonly line: number;
 
-  constructor(msg: string, line: number, options?: ErrorOptions) {
-    let _msg = `[Line ${line}]: ${msg}`;
-    if (options?.cause) {
-      _msg += `\nCaused by ${options.cause.toString()}\n${
-        (options.cause as Error).stack
-      }`;
-    }
-    super(_msg);
-    this.line = line;
-  }
+	constructor(msg: string, line: number, options?: ErrorOptions) {
+		let _msg = `[Line ${line}]: ${msg}`;
+		if (options?.cause) {
+			_msg += `\nCaused by ${options.cause.toString()}\n${
+				(options.cause as Error).stack
+			}`;
+		}
+		super(_msg);
+		this.line = line;
+	}
 }
 
 export class DxfStreamParser extends EventTarget {
-  public dxf: ParsedDxf = {
-    // @ts-ignore
-    header: {},
-    blocks: {},
-    entities: [],
-    tables: {},
-    objects: {
-      byName: {},
-      byTree: undefined,
-    },
-  };
+	public dxf: ParsedDxf = {
+		// @ts-ignore
+		header: {},
+		blocks: {},
+		entities: [],
+		tables: {},
+		objects: {
+			byName: {},
+			byTree: undefined,
+		},
+	};
 
-  private readonly _decoder: TextDecoder;
-  private readonly _pointParser: parsePoint;
+	private readonly _decoder: TextDecoder;
+	private readonly _pointParser: parsePoint;
 
-  constructor(options: DxfStreamParserOptions = new DxfStreamParserOptions()) {
-    super();
-    this._decoder = new TextDecoder(options.encoding, {
-      fatal: options.encodingFailureFatal,
-    });
-    this._pointParser = new parsePoint();
-  }
+	constructor(
+		options: DxfStreamParserOptions = new DxfStreamParserOptions()
+	) {
+		super();
+		this._decoder = new TextDecoder(options.encoding, {
+			fatal: options.encodingFailureFatal,
+		});
+		this._pointParser = new parsePoint();
+	}
 
-  private _finalChunkSeen: boolean = false;
-  private _curChunk: string = "";
-  private _curGroupCode: number | null = null;
-  private _curLineNum = 1;
+	private _finalChunkSeen: boolean = false;
+	private _curChunk: string = "";
+	private _curGroupCode: number | null = null;
+	private _curLineNum = 1;
 
-  private _eof = false;
-  private _curValue: ScannerGroup = { code: 0, value: 0 };
-  private _curSection: string = "";
-  private _currVarName: string = "";
+	private _eof = false;
+	private _curValue: ScannerGroup = { code: 0, value: 0 };
+	private _curSection: string = "";
+	private _currVarName: string = "";
 
-  private Feed(input: ArrayBuffer | null, isFinalChunk = false): void {
-    const s = this._decoder.decode(input ?? undefined, {
-      stream: !isFinalChunk,
-    });
-    this.FeedString(s, isFinalChunk);
-  }
+	private Feed(input: ArrayBuffer | null, isFinalChunk = false): void {
+		const s = this._decoder.decode(input ?? undefined, {
+			stream: !isFinalChunk,
+		});
+		this.FeedString(s, isFinalChunk);
+	}
 
-  /** Feed next string chunk to the parser. */
-  private FeedString(input: string, isFinalChunk = false): void {
-    if (this._finalChunkSeen) {
-      throw new Error("Data fed after final chunk processed");
-    }
-    if (isFinalChunk) {
-      this._finalChunkSeen = true;
-    }
-    this._curChunk += input;
-    this._ProcessCurChunk();
-    if (isFinalChunk) {
-      this._Finalize();
-    }
-  }
-  private _Finalize() {}
+	/** Feed next string chunk to the parser. */
+	private FeedString(input: string, isFinalChunk = false): void {
+		if (this._finalChunkSeen) {
+			throw new Error("Data fed after final chunk processed");
+		}
+		if (isFinalChunk) {
+			this._finalChunkSeen = true;
+		}
+		this._curChunk += input;
+		this._ProcessCurChunk();
+		if (isFinalChunk) {
+			this._Finalize();
+		}
+	}
+	private _Finalize() {}
 
-  async FeedFile(file: ArrayBuffer, abortSignal?: AbortSignal): Promise<void> {
-    const size = file.byteLength;
-    const CHUNK_SIZE = 0x10000;
-    for (let offset = 0; offset < size; offset += CHUNK_SIZE) {
-      abortSignal?.throwIfAborted();
-      const chunkSize = Math.min(size - offset, CHUNK_SIZE);
-      const buf = await file.slice(offset, offset + chunkSize);
-      this.Feed(buf, offset + chunkSize >= size);
-    }
-  }
+	async FeedFile(
+		file: ArrayBuffer,
+		abortSignal?: AbortSignal
+	): Promise<void> {
+		const size = file.byteLength;
+		const CHUNK_SIZE = 0x10000;
+		for (let offset = 0; offset < size; offset += CHUNK_SIZE) {
+			abortSignal?.throwIfAborted();
+			const chunkSize = Math.min(size - offset, CHUNK_SIZE);
+			const buf = await file.slice(offset, offset + chunkSize);
+			this.Feed(buf, offset + chunkSize >= size);
+		}
+	}
 
-  private _ProcessCurChunk(): void {
-    for (const s of this._ConsumeCurChunkLines()) {
-      this._ProcessLine(s);
-      this._curLineNum++;
-      if (!this._eof) {
-        switch (this._curSection) {
-          case "HEADER":
-            let headerValue = this._curValue.value;
-            if (this._curValue.code === 9) {
-              this._currVarName = headerValue;
-            } else if (this._curValue.code === 10) {
-              this._pointParser.parseStart(this._curValue);
-            } else if (
-              this._pointParser.startCode === this._curValue.code ||
-              this._pointParser.startCode + 10 === this._curValue.code ||
-              this._pointParser.startCode + 20 === this._curValue.code
-            ) {
-              headerValue = this._pointParser.setPoint(this._curValue);
-            } else {
-              if (this._currVarName)
-                this.dxf.header[this._currVarName] = headerValue;
-            }
-            break;
-          case "BLOCKS":
-            break;
-          case "ENTITIES":
-            break;
-          case "TABLES":
-            break;
-          case "OBJECTS":
-            break;
-        }
-      }
-    }
-  }
+	private _ProcessCurChunk(): void {
+		for (const s of this._ConsumeCurChunkLines()) {
+			this._ProcessLine(s);
+			this._curLineNum++;
+			if (!this._eof) {
+				switch (this._curSection) {
+					case "HEADER":
+						let headerValue = this._curValue.value;
+						if (this._curValue.code === 9) {
+							this._currVarName = headerValue as string;
+						} else if (this._curValue.code === 10) {
+							this._pointParser.parseStart(this._curValue);
+						} else if (
+							this._pointParser.startCode ===
+								this._curValue.code ||
+							this._pointParser.startCode + 10 ===
+								this._curValue.code ||
+							this._pointParser.startCode + 20 ===
+								this._curValue.code
+						) {
+							headerValue = this._pointParser.setPoint(
+								this._curValue
+							);
+						} else {
+							if (this._currVarName) {
+								const name = this._currVarName;
+								// 원본 보존
+								this.dxf.header[name] = headerValue;
+								// 정규화된 키들 동시 저장
+								const canonical = name.replace(/^\$+/, "");
+								if (canonical) {
+									const upper = canonical.toUpperCase();
+									this.dxf.header[canonical] = headerValue; // 무달러
+									this.dxf.header[`$${canonical}`] =
+										headerValue; // 싱글달러
+									this.dxf.header[upper] = headerValue; // 무달러+대문자
+									this.dxf.header[`$${upper}`] = headerValue; // 싱글달러+대문자
+								}
+							}
+						}
+						break;
+					case "BLOCKS":
+						break;
+					case "ENTITIES":
+						break;
+					case "TABLES":
+						break;
+					case "OBJECTS":
+						break;
+				}
+			}
+		}
+	}
 
-  private *_ConsumeCurChunkLines(): IterableIterator<string> {
-    let pos = 0;
-    const n = this._curChunk.length;
-    while (pos < n) {
-      let sepPos = this._curChunk.indexOf("\r", pos);
-      let nextPos = 0;
-      if (sepPos >= 0) {
-        nextPos = sepPos + 1;
-        if (nextPos < n && this._curChunk.charAt(nextPos) == "\n") {
-          nextPos++;
-        }
-      } else {
-        sepPos = this._curChunk.indexOf("\n", pos);
-        if (sepPos >= 0) {
-          nextPos = sepPos + 1;
-        }
-      }
-      if (sepPos < 0) {
-        break;
-      }
-      yield this._curChunk.substring(pos, sepPos);
-      pos = nextPos;
-    }
-    if (pos != 0) {
-      this._curChunk = this._curChunk.substring(pos);
-    }
-  }
-  private _ProcessLine(line: string): void {
-    if (this._curGroupCode === null) {
-      const codeStr = line.trim();
-      this._curGroupCode = parseInt(codeStr);
-      if (isNaN(this._curGroupCode)) {
-        this._Error("Bad group code: " + codeStr);
-      }
-      return;
-    }
-    const token = new Token(this._curGroupCode, line);
+	private *_ConsumeCurChunkLines(): IterableIterator<string> {
+		let pos = 0;
+		const n = this._curChunk.length;
+		while (pos < n) {
+			let sepPos = this._curChunk.indexOf("\r", pos);
+			let nextPos = 0;
+			if (sepPos >= 0) {
+				nextPos = sepPos + 1;
+				if (nextPos < n && this._curChunk.charAt(nextPos) == "\n") {
+					nextPos++;
+				}
+			} else {
+				sepPos = this._curChunk.indexOf("\n", pos);
+				if (sepPos >= 0) {
+					nextPos = sepPos + 1;
+				}
+			}
+			if (sepPos < 0) {
+				break;
+			}
+			yield this._curChunk.substring(pos, sepPos);
+			pos = nextPos;
+		}
+		if (pos != 0) {
+			this._curChunk = this._curChunk.substring(pos);
+		}
+	}
+	private _ProcessLine(line: string): void {
+		if (this._curGroupCode === null) {
+			const codeStr = line.trim();
+			this._curGroupCode = parseInt(codeStr);
+			if (isNaN(this._curGroupCode)) {
+				this._Error("Bad group code: " + codeStr);
+			}
+			return;
+		}
+		const token = new Token(this._curGroupCode, line);
 
-    if (!isMatched(token, 0, "EOF")) {
-      switch (token.value) {
-        case "SECTION":
-          this._curSection = "SECTION";
-          break;
-        case "HEADER":
-          this._curSection = "HEADER";
-          break;
-        case "BLOCKS":
-          this._curSection = "BLOCKS";
-          break;
-        case "ENTITIES":
-          this._curSection = "ENTITIES";
-          break;
-        case "TABLES":
-          this._curSection = "TABLES";
-          break;
-        case "OBJECTS":
-          this._curSection = "OBJECTS";
-          break;
-      }
-      this._eof = false;
-    }
-    if (isMatched(token, 0, "EOF")) {
-      this._eof = true;
-    }
-    this._curValue = token;
-    this._curGroupCode = null;
-  }
-  private _Error(msg: string, cause: any | null = null) {
-    let options = undefined;
-    if (cause) {
-      options = { cause };
-    }
-    throw new DxfParsingError(msg, this._curLineNum, options);
-  }
+		if (!isMatched(token, 0, "EOF")) {
+			switch (token.value) {
+				case "SECTION":
+					this._curSection = "SECTION";
+					break;
+				case "HEADER":
+					this._curSection = "HEADER";
+					break;
+				case "BLOCKS":
+					this._curSection = "BLOCKS";
+					break;
+				case "ENTITIES":
+					this._curSection = "ENTITIES";
+					break;
+				case "TABLES":
+					this._curSection = "TABLES";
+					break;
+				case "OBJECTS":
+					this._curSection = "OBJECTS";
+					break;
+			}
+			this._eof = false;
+		}
+		if (isMatched(token, 0, "EOF")) {
+			this._eof = true;
+		}
+		this._curValue = token;
+		this._curGroupCode = null;
+	}
+	private _Error(msg: string, cause: any | null = null) {
+		let options = undefined;
+		if (cause) {
+			options = { cause };
+		}
+		throw new DxfParsingError(msg, this._curLineNum, options);
+	}
 }
 
 class Token {
-  readonly code: number;
-  readonly value: string | number | boolean;
+	readonly code: number;
+	readonly value: string | number | boolean;
 
-  constructor(code: number, valueStr: string) {
-    this.code = code;
-    this.value = parseGroupValue(code, valueStr);
-  }
+	constructor(code: number, valueStr: string) {
+		this.code = code;
+		this.value = parseGroupValue(code, valueStr);
+	}
 }


### PR DESCRIPTION
AutoCAD uses $DIMSE1, while some DXF files may contain DIMSE1 or even $$DIMSE1. To ensure consistent access regardless of header key notation, key normalization was introduced. Now, the following keys all return the same value: header['$DIMSE1'], header['DIMSE1'], header['$DIMSE1'.toUpperCase()], and header['DIMSE1'.toUpperCase()].

This resolves DIM-related inconsistencies caused by header key format differences.

Click preview and choose a template

- [Changes](?template=changes.md)
- [Release](?template=release.md)
