### PR TITLE
chore: update node version for runner

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm install
       - run: npm run build
 
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm install
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm install
       - run: npm run build
       - run: npm install --install-links # this is required since github action ignore symlink

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - run: npm install


### PR DESCRIPTION
## Overview

- Change action runner version as Node 24 as they [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- Related to #159 but this wasn't the cure, it was token authority issue

## Changes

Check the relevants of your pull request

- [ ] Add new features
- [ ] Fix bug
- [ ] Refactor which doesn't change internal behavior (indent, typo)
- [ ] Refactor which do changes internal behavior
- [ ] Edit the existing documents/comments
- [x] Edit the build part or package manager

## Approval Requirement

- Title of the PR must start with one of them: (choose the most important one of above changes)
  - `feat: `
  - `fix: `
  - `chore: `
  - `refactor: `
- You must apply prettier
- You should add test cases for new feature(s) (especially for complex cases)
- You should add **jsdoc comment** to `function`, `type`, `interface` and constants.
- You must add followings to `import-test.ts` and **pass the test**
  - New parser snippets
  - New `enum` and constants
  - New parse `function`
  - Helper functions or internal things are optional, but the maintainer would request to add them.

You can test by yourself in local, by executing following commands:

```
npm run build
npm run test
```
